### PR TITLE
fix: Emptykey_fix

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,8 @@ func ReadConfig(c *config.Config, path ...string) error {
 		return nil
 	}
 	if c.Spec.Jwt.Key == "" {
-		v.Set("spec.jwt.key", generate(32))
+		c.Spec.Jwt.Key = generate(32)
+		v.Set("spec.jwt.key", c.Spec.Jwt.Key)
 		if err := v.WriteConfig(); err != nil {
 			return err
 		}


### PR DESCRIPTION
修复首次启动key为空的问题。确保在首次启动程序时，不仅更新配置文件中的key值，还同步更新当前程序中的key值，避免首次启动时key为空。