### PR TITLE
fix：202 issues。进行容器文件相关操作时(创建文件，更新文件，查看文件，上传文件)，前端入参数据类型从表单数据修改为json数据

### DIFF
--- a/web/dashboard/src/plugins/request.js
+++ b/web/dashboard/src/plugins/request.js
@@ -117,7 +117,7 @@ export const del = (url, loading) => {
 }
 
 export const postFile= (url,data, params,loading) => {
-  return promise(request({url: url, method: "post",data: data,params:params, headers:{"Content-Type":"multipart/form-data"},timeout:600000}), loading)
+  return promise(request({url: url, method: "post",data: data,params:params, headers:{"Content-Type":"application/json"},timeout:600000}), loading)
 }
 
 export const patch = (url, data, headers, loading) => {


### PR DESCRIPTION
What this PR does / why we need it?
fix this issues https://github.com/1Panel-dev/KubePi/issues/202

Summary of your change
Change the input parameter data type in the front-end postFile method from "multipart/form-data" to "application/json"

Please indicate you've done the following:
I modified the code on my branch, recompiled it, ran kubepi-server, and verified the step of viewing the container file. The file data was successfully viewed, as shown below