### PR TITLE
fixed: 获取pod域名时的页面脚本空值错误

### DIFF
--- a/web/dashboard/src/business/workloads/pods/detail/index.vue
+++ b/web/dashboard/src/business/workloads/pods/detail/index.vue
@@ -183,7 +183,7 @@ export default {
     },
     async get_pod_domain(){
       let ip = "";
-      if (this.form.status.podIPs.length > 0) {
+      if (this.form.status.podIPs && this.form.status.podIPs.length > 0) {
          ip = this.form.status.podIP.replaceAll(".", "-");
       }
       this.ip=ip


### PR DESCRIPTION
fixed: 获取pod域名时的页面脚本空值错误